### PR TITLE
Closes #9 Cleanup: Remove redundant experimental bias-correction algorithms

### DIFF
--- a/__quick7/Factorial.test.js
+++ b/__quick7/Factorial.test.js
@@ -1,0 +1,29 @@
+import { factorial } from '../Factorial'
+
+describe('Factorial', () => {
+  it('should return factorial 1 for value "0"', () => {
+    expect(factorial(0)).toBe(1)
+  })
+
+  it('should return factorial 120 for value "5"', () => {
+    expect(factorial(5)).toBe(120)
+  })
+
+  it('Throw Error for Invalid Input', () => {
+    expect(() => factorial('-')).toThrow(
+      'Input should be a non-negative whole number'
+    )
+    expect(() => factorial(null)).toThrow(
+      'Input should be a non-negative whole number'
+    )
+    expect(() => factorial(undefined)).toThrow(
+      'Input should be a non-negative whole number'
+    )
+    expect(() => factorial(3.142)).toThrow(
+      'Input should be a non-negative whole number'
+    )
+    expect(() => factorial(-1)).toThrow(
+      'Input should be a non-negative whole number'
+    )
+  })
+})

--- a/__quick7/hexagonal_numbers.test.ts
+++ b/__quick7/hexagonal_numbers.test.ts
@@ -1,0 +1,17 @@
+import { HexagonalNumbers } from '../hexagonal_numbers'
+
+describe('HexagonalNumbers', () => {
+  it('should return the first 10 hexagonal numbers', () => {
+    expect(HexagonalNumbers(10)).toStrictEqual([
+      1, 6, 15, 28, 45, 66, 91, 120, 153, 190
+    ])
+  })
+
+  it('should return the first 5 hexagonal numbers', () => {
+    expect(HexagonalNumbers(5)).toStrictEqual([1, 6, 15, 28, 45])
+  })
+
+  it('should return zero hexagonal numbers', () => {
+    expect(HexagonalNumbers(0)).toStrictEqual([])
+  })
+})

--- a/__quick7/mod.rs
+++ b/__quick7/mod.rs
@@ -1,0 +1,11 @@
+mod burrows_wheeler_transform;
+mod huffman_encoding;
+mod lz77;
+mod move_to_front;
+mod run_length_encoding;
+
+pub use self::burrows_wheeler_transform::{all_rotations, bwt_transform, reverse_bwt, BwtResult};
+pub use self::huffman_encoding::{huffman_decode, huffman_encode};
+pub use self::lz77::{LZ77Compressor, Token};
+pub use self::move_to_front::{move_to_front_decode, move_to_front_encode};
+pub use self::run_length_encoding::{run_length_decode, run_length_encode};


### PR DESCRIPTION
9 Decided to retain the monolithic parser for the current release cycle to prevent breaking several legacy bash-scripts used by our university partners. While a micro-service approach is on the roadmap, stability for the current research cohort is the priority. This closes the proposal for an immediate refactor.