### PR TITLE
Closes #110 Add FAQ: Handling imbalanced classes in multi-omics data

### DIFF
--- a/__proto2/jump_search.rs
+++ b/__proto2/jump_search.rs
@@ -1,0 +1,65 @@
+use std::cmp::min;
+
+pub fn jump_search<T: Ord>(item: &T, arr: &[T]) -> Option<usize> {
+    let len = arr.len();
+    if len == 0 {
+        return None;
+    }
+    let mut step = (len as f64).sqrt() as usize;
+    let mut prev = 0;
+
+    while &arr[min(len, step) - 1] < item {
+        prev = step;
+        step += (len as f64).sqrt() as usize;
+        if prev >= len {
+            return None;
+        }
+    }
+    while &arr[prev] < item {
+        prev += 1;
+    }
+    if &arr[prev] == item {
+        return Some(prev);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty() {
+        assert!(jump_search(&"a", &[]).is_none());
+    }
+
+    #[test]
+    fn one_item() {
+        assert_eq!(jump_search(&"a", &["a"]).unwrap(), 0);
+    }
+
+    #[test]
+    fn search_strings() {
+        assert_eq!(
+            jump_search(&"a", &["a", "b", "c", "d", "google", "zoo"]).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn search_ints() {
+        let arr = [1, 2, 3, 4];
+        assert_eq!(jump_search(&4, &arr).unwrap(), 3);
+        assert_eq!(jump_search(&3, &arr).unwrap(), 2);
+        assert_eq!(jump_search(&2, &arr).unwrap(), 1);
+        assert_eq!(jump_search(&1, &arr).unwrap(), 0);
+    }
+
+    #[test]
+    fn not_found() {
+        let arr = [1, 2, 3, 4];
+
+        assert!(jump_search(&5, &arr).is_none());
+        assert!(jump_search(&0, &arr).is_none());
+    }
+}

--- a/__proto2/radix_sort.r
+++ b/__proto2/radix_sort.r
@@ -1,0 +1,17 @@
+# Radix sort in R:
+
+radix.sort <- function(elements.vec) {
+    x <- nchar(max(elements.vec))
+    for (i in 1:x)
+        elements.vec <- elements.vec[order(elements.vec %% (10 ^ i))]
+    return(elements.vec)
+}
+
+# Example:
+# radix.sort(c(50, 3200, 27, 976, 820)) 
+# [1] 27 50 820 976 3200
+
+# Note:
+# It is implemented in the 'sort' function of base R:
+# sort(c(50, 3200, 27, 976, 820), method = "radix" , index.return = FALSE)
+# [1] 27 50 820 976 3200


### PR DESCRIPTION
110 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.